### PR TITLE
fix/non_existent_recognition_links

### DIFF
--- a/src/logic/api/serializers/text.py
+++ b/src/logic/api/serializers/text.py
@@ -3,4 +3,4 @@ from rest_framework import serializers
 
 class TextSerializer(serializers.Serializer):
     ready: serializers.BooleanField = serializers.BooleanField()
-    text: serializers.CharField = serializers.CharField()
+    text: serializers.CharField = serializers.CharField(allow_blank=True)

--- a/src/logic/models.py
+++ b/src/logic/models.py
@@ -92,17 +92,19 @@ class AudioData:
     @property
     def text(self) -> str:
         if not self.__text:
-            cached_result: str = services.cache.get(self.__hexdigest)
+            cached_result: str = services.cache.get_finished(self.__hexdigest)
 
             if cached_result:
                 self.__text = cached_result
 
             else:
+                services.cache.set_started(self.__hexdigest, 'True')
+
                 self.__data = services.converter.convert(self.__data)
                 result: str = services.recognition.recognize(self.__data)
                 self.__text = result
 
-                services.cache.set(self.__hexdigest, self.__text)
+                services.cache.set_finished(self.__hexdigest, self.__text)
 
         return self.__text
 

--- a/src/logic/services/cache.py
+++ b/src/logic/services/cache.py
@@ -6,13 +6,27 @@ class Cache:
     def __init__(self) -> None:
         pass
 
-    def get(self, key: str) -> str:
-        value = cache.get(key, '')
+    def get_started(self, key: str) -> str:
+        result = self.__get(key, 1)
+        return result
+
+    def get_finished(self, key: str) -> str:
+        result = self.__get(key, 2)
+        return result
+
+    def __get(self, key: str, version: int) -> str:
+        value = cache.get(key, '', version=version)
 
         if value:
-            cache.touch(key)
+            cache.touch(key, version=version)
 
         return value
 
-    def set(self, key: str, value: str) -> None:
-        cache.set(key, value)
+    def set_started(self, key: str, value: str) -> None:
+        self.__set(key, value, 1)
+
+    def set_finished(self, key: str, value: str) -> None:
+        self.__set(key, value, 2)
+
+    def __set(self, key: str, value: str, version: int) -> None:
+        cache.set(key, value, version=version)

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -1,10 +1,17 @@
 import requests
+import pathlib
 
+
+POST_URL: str = 'http://localhost:8000/api/v1/file/'
 URL_LIST: str = 'http://localhost:8000/api/v1/text/'
 URL_DETAIL = (
     URL_LIST +
-    '10e0e1c3828817839a450f9895c85e975122801e27f65faee4cdb7d588b8e305/'
-) 
+    '337096cb374d208ebf4deae2eb365956c090ccfb1c9b7a35bda7874a803eb648/'
+)
+WRONG_URL_DETAIL = (
+    URL_LIST +
+    '1/'
+)
 TEXT: str = 'hano world'
 OPTIONS: dict = {
     "name": "Text Instance",
@@ -21,13 +28,21 @@ OPTIONS: dict = {
 }
 
 
+def payload(name: str):
+    file: pathlib.Path = pathlib.Path('tests', 'data', 'audio', name)
+    payload: dict = {'file': open(file, 'rb')}
+
+    return payload
+
+
 def test_get_list_404() -> None:
     response: requests.Response = requests.get(URL_LIST)
 
     assert response.status_code == 404
 
 
-def test_get_detail_404() -> None:
+def test_get_detail_200() -> None:
+    requests.post(POST_URL, files=payload('audio.aac'))
     response: requests.Response = requests.get(URL_DETAIL)
     data: dict = response.json()
 
@@ -36,7 +51,13 @@ def test_get_detail_404() -> None:
     assert 'text' in data.keys()
 
 
+def test_get_detail_404() -> None:
+    response: requests.Response = requests.get(WRONG_URL_DETAIL)
+    assert response.status_code == 404
+
+
 def test_head_detail_200() -> None:
+    requests.post(POST_URL, files=payload('audio.aac'))
     response: requests.Response = requests.head(URL_DETAIL)
 
     assert response.status_code == 200


### PR DESCRIPTION
Corrected the responses of the text endpoint when requesting links for which work never started. Now the 404 code is returned, the 200 code used to be, and the eternal state "ready is False", which could lead to errors for connected clients.