### PR TITLE
fix/denial_of_service

### DIFF
--- a/src/logic/models.py
+++ b/src/logic/models.py
@@ -92,6 +92,11 @@ class AudioData:
     @property
     def text(self) -> str:
         if not self.__text:
+            started: str = services.cache.get_started(self.__hexdigest)
+
+            if started:
+                return ''
+
             cached_result: str = services.cache.get_finished(self.__hexdigest)
 
             if cached_result:

--- a/src/logic/tasks.py
+++ b/src/logic/tasks.py
@@ -10,7 +10,9 @@ def start_recognition(
 ) -> None:
     audio_data: AudioData = AudioData(audio_bytes, audio_bytes_hexdigest)
     audio_data_text: str = audio_data.text
-    text_hexdigest: StringHexdigest = StringHexdigest(audio_data_text)
 
-    new_log: Logs = Logs(ip=ip, hash=text_hexdigest.value)
-    new_log.save()
+    if audio_data_text:
+        text_hexdigest: StringHexdigest = StringHexdigest(audio_data_text)
+
+        new_log: Logs = Logs(ip=ip, hash=text_hexdigest.value)
+        new_log.save()


### PR DESCRIPTION
Added a condition that allows server to avoid failure when sending the same file to it non-stop. Now, if you send the same audio file non-stop, only the first one will be recognized. Previously, a similar condition was triggered after recognizing the first file - now immediately.