### PR TITLE
fix: recognition of long audio

### DIFF
--- a/src/logic/api/viewsets/text.py
+++ b/src/logic/api/viewsets/text.py
@@ -34,6 +34,7 @@ class TextViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
 
             if text:
                 ready = True
+                services.cache.refresh(audio_hexdigest)
 
             response_data: TextSerializer = TextSerializer(
                 data={'ready': ready, 'text': text}

--- a/src/logic/services/cache.py
+++ b/src/logic/services/cache.py
@@ -7,26 +7,20 @@ class Cache:
         pass
 
     def get_started(self, key: str) -> str:
-        result = self.__get(key, 1)
+        result = cache.get(key, '', version=1)
         return result
 
     def get_finished(self, key: str) -> str:
-        result = self.__get(key, 2)
+        result = cache.get(key, '', version=2)
         return result
 
-    def __get(self, key: str, version: int) -> str:
-        value = cache.get(key, '', version=version)
-
-        if value:
-            cache.touch(key, version=version)
-
-        return value
-
     def set_started(self, key: str, value: str) -> None:
-        self.__set(key, value, 1)
+        cache.set(key, value, None, 1)
 
     def set_finished(self, key: str, value: str) -> None:
-        self.__set(key, value, 2)
+        cache.set(key, value, version=2)
+        cache.set(key, value, version=1)
 
-    def __set(self, key: str, value: str, version: int) -> None:
-        cache.set(key, value, version=version)
+    def refresh(self, key: str) -> None:
+        cache.touch(key, version=1)
+        cache.touch(key, version=2)


### PR DESCRIPTION
Fixed cases where links to recognized text disappeared during recognition due to long recognition. For example, the audio link to the text of the recognized audio could disappear if recognition took longer than the time of storing objects in the cache.