### PR TITLE
fix/large_audios

### DIFF
--- a/src/logic/api/serializers/file.py
+++ b/src/logic/api/serializers/file.py
@@ -11,6 +11,8 @@ class FileSerializer(serializers.Serializer):
     def validate_file(
         self, file: InMemoryUploadedFile
     ) -> InMemoryUploadedFile:
+        too_long: bool = False
+
         try:
             bytes_io: BytesIO | Any = file.file
 
@@ -20,8 +22,16 @@ class FileSerializer(serializers.Serializer):
 
             bytes_io_: BytesIO = BytesIO(bytes_)
 
-            AudioSegment.from_file(bytes_io_)
+            audio = AudioSegment.from_file(bytes_io_)
+
+            if audio.duration_seconds > 30:
+                too_long = True
+
         except Exception:
             raise serializers.ValidationError('Not an audio file.')
+
+        if too_long:
+            message: str = 'The audio should be shorter than 30 seconds.'
+            raise serializers.ValidationError(message)
 
         return file


### PR DESCRIPTION
Added validation of the audio file length, so for too large audio files, a link is created to get the result, but they cannot be recognized. Set the maximum length to 30 seconds.